### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,13 @@ project(PetSpectAnalysis)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "http://gti-fing.github.io/SlicerPetSpectAnalysis")
+set(EXTENSION_HOMEPAGE "https://gti-fing.github.io/SlicerPetSpectAnalysis")
 set(EXTENSION_CATEGORY "Nuclear Medicine")
 set(EXTENSION_CONTRIBUTORS "Martin Bertran, Natalia Martinez Gil, Guillermo Carbajal, Alvaro Gomez (Facultad de Ingenieria, Uruguay)")
 # set(EXTENSION_DESCRIPTION "Pet Spect Analysis Extension contains two modules: dPetBrainQuantification and EpileptogenicFocusDetection")
-set(EXTENSION_DESCRIPTION "Pet Spect Analysis Extension")
-set(EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/b/b1/DPetBrainQuantification.png")
-set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/e/e4/ProcessingBlocks.png http://www.slicer.org/slicerWiki/images/7/76/InformationPanel.png http://www.slicer.org/slicerWiki/images/2/2a/VisualizationPanel.png http://www.slicer.org/slicerWiki/images/2/24/CarotidSegmentation.png http://www.slicer.org/slicerWiki/images/b/bb/CarotidSegmentationROI.png http://www.slicer.org/slicerWiki/images/5/51/PTACEstimationIDIF.png http://www.slicer.org/slicerWiki/images/9/98/PTACEstimationPBIF.png http://www.slicer.org/slicerWiki/images/9/90/KMap.png")
+set(EXTENSION_DESCRIPTION "First Version of the Pet Spect Analysis Extension")
+set(EXTENSION_ICONURL "https://www.slicer.org/slicerWiki/images/b/b1/DPetBrainQuantification.png")
+set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/slicerWiki/images/e/e4/ProcessingBlocks.png https://www.slicer.org/slicerWiki/images/7/76/InformationPanel.png https://www.slicer.org/slicerWiki/images/2/2a/VisualizationPanel.png https://www.slicer.org/slicerWiki/images/2/24/CarotidSegmentation.png https://www.slicer.org/slicerWiki/images/b/bb/CarotidSegmentationROI.png https://www.slicer.org/slicerWiki/images/5/51/PTACEstimationIDIF.png https://www.slicer.org/slicerWiki/images/9/98/PTACEstimationPBIF.png https://www.slicer.org/slicerWiki/images/9/90/KMap.png")
 
 #-----------------------------------------------------------------------------
 # Extension dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.